### PR TITLE
Registration format 1.2

### DIFF
--- a/samples/registration-1.2/customEventCombinedEvent.xml
+++ b/samples/registration-1.2/customEventCombinedEvent.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<registration version="1.2" location="Berlin" date="2022-06-17" name="Testveranstaltung" competitionnumber="21L20000000003200">
+    <vendor vendor="LADV" programname="LADV" programversion="&lt;version&gt;" website="https://ladv.de"/>
+    <clubs>
+        <club id="C1" number="1234" guid="12345678-abcd-abcd-abcd-cccccccccc01" type="CLUB" name="TSV Besteck" shortname="TSV Besteck" country="GER" region="WÜ"/>
+    </clubs>
+    <athletes>
+        <athlete id="A1" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa01" forename="Martin" lastname="Messer" yearofbirth="2000" sex="M" club="C1" country="GER" licencenumber="12345"/>
+        <athlete id="A2" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa02" forename="Gerd" lastname="Gabel" yearofbirth="1999" sex="M" club="C1" country="GER" licencenumber="12346"/>
+        <athlete id="A3" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa03" forename="Leander" lastname="Löffel" yearofbirth="1999" sex="M" club="C1" country="GER" licencenumber="12346"/>
+    </athletes>
+    <eventdefinitions>
+        <eventdefinition id="ED1" name="Sprint 3-Kampf (60m/80m/100m)" shortname="Sprint 3-Kampf" eventtype="COMBINEDEVENT" formattype="POINTS" precision="POINTS_FULL"/>
+    </eventdefinitions>
+    <events>
+        <event id="E1" agecode="M">
+            <customevent eventdefinition="ED1"/>
+        </event>
+    </events>
+    <individuals>
+        <individual id="I1" event="E1" athlete="A1"/>
+        <individual id="I2" event="E1" athlete="A2"/>
+        <individual id="I3" event="E1" athlete="A3"/>
+    </individuals>
+</registration>
+

--- a/samples/registration-1.2/customEventRelay.xml
+++ b/samples/registration-1.2/customEventRelay.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<registration version="1.2" location="Berlin" date="2022-06-17" name="Testveranstaltung" competitionnumber="21L20000000003200">
+    <vendor vendor="LADV" programname="LADV" programversion="&lt;version&gt;" website="https://ladv.de"/>
+    <clubs>
+        <club id="C1" number="1234" guid="12345678-abcd-abcd-abcd-cccccccccc01" type="CLUB" name="TSV Besteck" shortname="TSV Besteck" country="GER" region="WÜ"/>
+    </clubs>
+    <athletes>
+        <athlete id="A1" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa01" forename="Martin" lastname="Messer" yearofbirth="2000" sex="M" club="C1" country="GER" licencenumber="12345"/>
+        <athlete id="A2" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa02" forename="Gerd" lastname="Gabel" yearofbirth="1999" sex="M" club="C1" country="GER" licencenumber="12346"/>
+        <athlete id="A3" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa03" forename="Leander" lastname="Löffel" yearofbirth="1999" sex="M" club="C1" country="GER" licencenumber="12346"/>
+    </athletes>
+    <eventdefinitions>
+        <eventdefinition id="ED1" name="2x100m Staffel" shortname="2x100m" eventtype="RELAY" formattype="TIME" precision="SECOND_100TH" vendorcode="RELAY:2x100"/>
+    </eventdefinitions>
+    <events>
+        <event id="E1" agecode="M">
+            <customevent eventdefinition="ED1"/>
+        </event>
+    </events>
+    <relays>
+        <relay id="R1" club="C1" event="E1" lateregistration="true" notranked="true">
+            <participant athlete="A1" id="P1"/>
+            <participant athlete="A2" id="P2"/>
+            <participant athlete="A3" id="P3"/>
+        </relay>
+    </relays>
+</registration>
+

--- a/samples/registration-1.2/customEventSprint.xml
+++ b/samples/registration-1.2/customEventSprint.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<registration version="1.2" location="Berlin" date="2022-06-17" name="Testveranstaltung" competitionnumber="21L20000000003200">
+    <vendor vendor="LADV" programname="LADV" programversion="&lt;version&gt;" website="https://ladv.de"/>
+    <clubs>
+        <club id="C1" number="1234" guid="12345678-abcd-abcd-abcd-cccccccccc01" type="CLUB" name="TSV Besteck" shortname="TSV Besteck" country="GER" region="WÜ"/>
+    </clubs>
+    <athletes>
+        <athlete id="A1" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa01" forename="Martin" lastname="Messer" yearofbirth="2000" sex="M" club="C1" country="GER" licencenumber="12345"/>
+        <athlete id="A2" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa02" forename="Gertrud" lastname="Gabel" yearofbirth="1999" sex="W" club="C1" country="GER" licencenumber="12346"/>
+    </athletes>
+    <eventdefinitions>
+        <eventdefinition id="ED1" name="117m Sprint" shortname="117m" eventtype="INDIVIDUAL" formattype="TIME" precision="SECOND_100TH" vendorcode="S117m"/>
+    </eventdefinitions>
+    <events>
+        <event id="E1" agecode="M">
+            <customevent eventdefinition="ED1"/>
+        </event>
+        <event id="E2" agecode="W">
+            <customevent eventdefinition="ED1"/>
+        </event>
+    </events>
+    <individuals>
+        <individual id="I1" event="E1" athlete="A1"/>
+        <individual id="I2" event="E2" athlete="A2"/>
+    </individuals>
+</registration>
+

--- a/samples/registration-1.2/kila.xml
+++ b/samples/registration-1.2/kila.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<registration version="1.2" location="Berlin" date="2022-06-17" name="Testveranstaltung" competitionnumber="21L20000000003200">
+    <vendor vendor="LADV" programname="LADV" programversion="&lt;version&gt;" website="https://ladv.de"/>
+    <clubs>
+        <club id="C1" number="1234" guid="12345678-abcd-abcd-abcd-cccccccccc01" type="CLUB" name="TSV Besteck" shortname="TSV Besteck" country="GER" region="WÜ"/>
+        <club id="C2" number="4567" guid="12345678-abcd-abcd-abcd-cccccccccc02" type="CLUB" name="SV Obst und Gemüse" shortname="SV Obst&amp;Gemüse" country="GER" region="WÜ"/>
+    </clubs>
+    <athletes>
+        <athlete id="A1" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa01" forename="Martin" lastname="Messer" yearofbirth="2011" sex="M" club="C1" country="GER" licencenumber="12345"/>
+        <athlete id="A2" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa02" forename="Gertrud" lastname="Gabel" yearofbirth="2011" sex="W" club="C1" country="GER" licencenumber="12346"/>
+        <athlete id="A3" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa03" forename="Adrian" lastname="Apfel" yearofbirth="2011" sex="M" club="C2" country="GER" licencenumber="20001"/>
+        <athlete id="A4" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa04" forename="Betina" lastname="Birne" yearofbirth="2011" sex="W" club="C2" country="GER" licencenumber="20002"/>
+        <athlete id="A5" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa05" forename="Doris" lastname="Dattel" yearofbirth="2012" sex="W" club="C2" country="GER" licencenumber="20003"/>
+        <athlete id="A6" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa06" forename="Einar" lastname="Erbse" yearofbirth="2012" sex="M" club="C2" country="GER" licencenumber="20004"/>
+    </athletes>
+    <eventdefinitions/>
+    <events>
+        <event id="E1" agecode="TU12">
+            <standardevent disciplinecode="KKILA"/>
+        </event>
+    </events>
+    <kilas>
+        <kila id="K1" name="Neckar Sprinter" club="C1" event="E1">
+            <participant athlete="A1" id="P1"/>
+            <participant athlete="A2" id="P2"/>
+            <participant athlete="A3" id="P3"/>
+            <participant athlete="A4" id="P4"/>
+            <participant athlete="A5" id="P5"/>
+            <participant athlete="A6" id="P6"/>
+        </kila>
+    </kilas>
+</registration>
+

--- a/samples/registration-1.2/lateregistration.xml
+++ b/samples/registration-1.2/lateregistration.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<registration version="1.2" location="Berlin" date="2022-06-17" name="Testveranstaltung" competitionnumber="21L20000000003200">
+    <vendor vendor="LADV" programname="LADV" programversion="&lt;version&gt;" website="https://ladv.de"/>
+    <clubs>
+        <club id="C1" number="1234" guid="12345678-abcd-abcd-abcd-cccccccccc01" type="CLUB" name="TSV Musterverein" shortname="TSV Musterverein" country="GER" region="WÜ"/>
+    </clubs>
+    <athletes>
+        <athlete id="A1" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa01" forename="Martin" lastname="Messer" yearofbirth="2000" sex="M" club="C1" country="GER" licencenumber="12345"/>
+        <athlete id="A2" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa02" forename="Gabriel" lastname="Gabel" yearofbirth="2000" sex="M" club="C1" country="GER" licencenumber="12346"/>
+    </athletes>
+    <eventdefinitions/>
+    <events>
+        <event id="E1" agecode="M">
+            <standardevent disciplinecode="L100"/>
+        </event>
+        <event id="E2" agecode="M">
+            <standardevent disciplinecode="TSPE_0800"/>
+        </event>
+        <event id="E3" agecode="M">
+            <standardevent disciplinecode="X4X1"/>
+        </event>
+    </events>
+    <individuals>
+        <individual id="I1" event="E1" athlete="A1"/>
+        <individual id="I2" event="E1" athlete="A2" lateregistration="true"/>
+        <individual id="I3" event="E2" athlete="A1"/>
+        <individual id="I4" event="E2" athlete="A2" lateregistration="true"/>
+    </individuals>
+    <relays>
+        <relay id="R1" club="C1" event="E3" lateregistration="true">
+            <participant athlete="A1" id="P1"/>
+            <participant athlete="A2" id="P2"/>
+        </relay>
+    </relays>
+</registration>
+

--- a/samples/registration-1.2/minimal.xml
+++ b/samples/registration-1.2/minimal.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<registration version="1.2" location="Berlin" date="2022-06-17" name="Testveranstaltung" competitionnumber="21L20000000003200">
+    <vendor vendor="LADV" programname="LADV" programversion="&lt;version&gt;" website="https://ladv.de"/>
+    <clubs>
+        <club id="C1" number="1234" guid="12345678-abcd-abcd-abcd-cccccccccc01" type="CLUB" name="TSV Besteck" shortname="TSV Besteck" country="GER" region="WÜ"/>
+    </clubs>
+    <athletes>
+        <athlete id="A1" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa01" forename="Martin" lastname="Messer" yearofbirth="2002" sex="M" club="C1" country="GER" licencenumber="12345"/>
+        <athlete id="A2" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa02" forename="Leon" lastname="Löffel" yearofbirth="2002" sex="M" club="C1" country="GER" licencenumber="12346"/>
+        <athlete id="A3" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa03" forename="Theo" lastname="Tortenheber" yearofbirth="2002" sex="M" club="C1" country="GER" licencenumber="12347"/>
+        <athlete id="A4" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa04" forename="Gertrud" lastname="Gabel" yearofbirth="2002" sex="W" club="C1" country="GER" licencenumber="12348"/>
+    </athletes>
+    <eventdefinitions/>
+    <events>
+        <event id="E1" agecode="M">
+            <standardevent disciplinecode="L100"/>
+        </event>
+        <event id="E2" agecode="M">
+            <standardevent disciplinecode="TWEI"/>
+        </event>
+        <event id="E3" agecode="M">
+            <standardevent disciplinecode="TKUG_7260"/>
+        </event>
+        <event id="E4" agecode="M">
+            <standardevent disciplinecode="THAM_7260"/>
+        </event>
+        <event id="E5" agecode="M">
+            <standardevent disciplinecode="TDIS_2000"/>
+        </event>
+        <event id="E6" agecode="M">
+            <standardevent disciplinecode="H110_1067"/>
+        </event>
+        <event id="E7" agecode="W">
+            <standardevent disciplinecode="M7K"/>
+        </event>
+        <event id="E8" agecode="M">
+            <standardevent disciplinecode="X3X1"/>
+        </event>
+    </events>
+    <individuals>
+        <individual id="I1" event="E1" athlete="A1"/>
+        <individual id="I2" event="E2" athlete="A1"/>
+        <individual id="I3" event="E3" athlete="A1"/>
+        <individual id="I4" event="E4" athlete="A1"/>
+        <individual id="I5" event="E5" athlete="A1"/>
+        <individual id="I6" event="E6" athlete="A1"/>
+        <individual id="I7" event="E7" athlete="A4"/>
+    </individuals>
+    <relays>
+        <relay id="R1" club="C1" event="E8">
+            <participant athlete="A1" id="P1"/>
+            <participant athlete="A2" id="P2"/>
+            <participant athlete="A3" id="P3"/>
+        </relay>
+    </relays>
+</registration>
+

--- a/samples/registration-1.2/mixedagegroup.xml
+++ b/samples/registration-1.2/mixedagegroup.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<registration version="1.2" location="Berlin" date="2022-06-17" name="Testveranstaltung" competitionnumber="21L20000000003200">
+    <vendor vendor="LADV" programname="LADV" programversion="&lt;version&gt;" website="https://ladv.de"/>
+    <clubs>
+        <club id="C1" number="1234" guid="12345678-abcd-abcd-abcd-cccccccccc01" type="CLUB" name="TSV Musterverein" shortname="TSV Musterverein" country="GER" region="WÜ"/>
+    </clubs>
+    <athletes>
+        <athlete id="A1" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa01" forename="Martin" lastname="Messer" yearofbirth="2000" sex="M" club="C1" country="GER" licencenumber="12345"/>
+        <athlete id="A2" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa02" forename="Gabriel" lastname="Gabel" yearofbirth="2000" sex="M" club="C1" country="GER" licencenumber="12346"/>
+        <athlete id="A3" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa03" forename="Martina" lastname="Messer" yearofbirth="2000" sex="W" club="C1" country="GER" licencenumber="200003"/>
+        <athlete id="A4" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa03" forename="Gabriele" lastname="Gabel" yearofbirth="2000" sex="W" club="C1" country="GER" licencenumber="200004"/>
+    </athletes>
+    <eventdefinitions/>
+    <events>
+        <event id="E1" agecode="X">
+            <standardevent disciplinecode="L100"/>
+        </event>
+        <event id="E2" agecode="X">
+            <standardevent disciplinecode="X4X1"/>
+        </event>
+    </events>
+    <individuals>
+        <individual id="I1" event="E1" athlete="A1"/>
+        <individual id="I2" event="E1" athlete="A2"/>
+        <individual id="I3" event="E1" athlete="A3"/>
+        <individual id="I4" event="E1" athlete="A4"/>
+    </individuals>
+    <relays>
+        <relay id="R1" club="C1" event="E2">
+            <participant athlete="A1" id="P1"/>
+            <participant athlete="A2" id="P2"/>
+            <participant athlete="A3" id="P3"/>
+            <participant athlete="A4" id="P4"/>
+        </relay>
+    </relays>
+</registration>
+

--- a/samples/registration-1.2/notranked.xml
+++ b/samples/registration-1.2/notranked.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<registration version="1.2" location="Berlin" date="2022-06-17" name="Testveranstaltung" competitionnumber="21L20000000003200">
+    <vendor vendor="LADV" programname="LADV" programversion="&lt;version&gt;" website="https://ladv.de"/>
+    <clubs>
+        <club id="C1" number="1234" guid="12345678-abcd-abcd-abcd-cccccccccc01" type="CLUB" name="TSV Musterverein" shortname="TSV Musterverein" country="GER" region="WÜ"/>
+    </clubs>
+    <athletes>
+        <athlete id="A1" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa01" forename="Martin" lastname="Messer" yearofbirth="2000" sex="M" club="C1" country="GER" licencenumber="12345"/>
+        <athlete id="A2" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa02" forename="Gabriel" lastname="Gabel" yearofbirth="2000" sex="M" club="C1" country="GER" licencenumber="12346"/>
+    </athletes>
+    <eventdefinitions/>
+    <events>
+        <event id="E1" agecode="M">
+            <standardevent disciplinecode="L100"/>
+        </event>
+        <event id="E2" agecode="M">
+            <standardevent disciplinecode="X4X1"/>
+        </event>
+    </events>
+    <individuals>
+        <individual id="I1" event="E1" athlete="A1"/>
+        <individual id="I2" event="E1" athlete="A2" notranked="true"/>
+    </individuals>
+    <relays>
+        <relay id="R1" club="C1" event="E2" notranked="true">
+            <participant athlete="A1" id="P1"/>
+            <participant athlete="A2" id="P2"/>
+        </relay>
+    </relays>
+</registration>
+

--- a/samples/registration-1.2/run.xml
+++ b/samples/registration-1.2/run.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<registration version="1.2" location="Berlin" date="2022-06-17" name="Testveranstaltung" competitionnumber="21L20000000003200">
+    <vendor vendor="LADV" programname="LADV" programversion="&lt;version&gt;" website="https://ladv.de"/>
+    <clubs>
+        <club id="C1" number="1234" guid="12345678-abcd-abcd-abcd-cccccccccc01" type="CLUB" name="TSV Besteck" shortname="TSV Besteck" country="GER" region="WÜ"/>
+        <club id="C2" number="1" type="OTHER" name="Vereinslos" shortname="TSV Besteck" country="GER" region="WÜ"/>
+    </clubs>
+    <athletes>
+        <athlete id="A1" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa01" forename="Martin" lastname="Messer" yearofbirth="2002" sex="M" club="C1" country="GER" licencenumber="12345"/>
+        <athlete id="A2" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa02" forename="Leon" lastname="Löffel" yearofbirth="2002" sex="M" club="C1" country="GER" licencenumber="12346"/>
+        <athlete id="A3" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa03" forename="Theo" lastname="Tortenheber" yearofbirth="2002" sex="M" club="C1" country="GER" licencenumber="12347"/>
+        <athlete id="A4" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa04" forename="Gertrud" lastname="Gabel" yearofbirth="2002" sex="W" club="C1" country="GER" licencenumber="12348"/>
+        <athlete id="A5" forename="Sonst" lastname="Wer" yearofbirth="2002" sex="M" club="C1" country="GER"/>
+    </athletes>
+    <eventdefinitions/>
+    <events/>
+    <runs>
+        <run id="RUN1" disciplinecode="S10K" name="10km Sport Eichenwald Hauptlauf" agecodes="M W M30 W30" distance="10000" trackid="GER-123456789">
+            <participant athlete="A1" id="P1"/>
+            <participant athlete="A2" id="P2"/>
+            <participant athlete="A5" id="P3"/>
+        </run>
+        <run id="RUN2" disciplinecode="SL" name="4,6km Hobbylauf" agecodes="M W M30 W30" distance="4700">
+            <participant athlete="A3" id="P4"/>
+            <participant athlete="A4" id="P5"/>
+            <participant athlete="A5" id="P6"/>
+        </run>
+        <run id="RUN3" disciplinecode="ALAUFAUFZEIT" name="30 Minuten Lauf" agecodes="M W M30 W30">
+            <participant athlete="A1" id="P7"/>
+            <participant athlete="A4" id="P8"/>
+            <participant athlete="A5" id="P9"/>
+        </run>
+    </runs>
+</registration>
+

--- a/samples/registration-1.2/sample.xml
+++ b/samples/registration-1.2/sample.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<registration version="1.2" location="Berlin" date="2022-06-17" name="Testveranstaltung" competitionnumber="21L20000000003200">
+    <vendor vendor="LADV" programname="LADV" programversion="&lt;version&gt;" website="https://ladv.de"/>
+    <clubs>
+        <club id="C1" number="1234" guid="12345678-abcd-abcd-abcd-cccccccccc01" type="CLUB" name="TSV Besteck" shortname="TSV Besteck" country="GER" region="WÜ"/>
+    </clubs>
+    <athletes>
+        <athlete id="A1" bib="1" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa01" forename="Martin" lastname="Messer" yearofbirth="2002" sex="M" club="C1" country="GER" licencenumber="12345"/>
+        <athlete id="A2" bib="2" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa02" forename="Leon" lastname="Löffel" yearofbirth="2002" sex="M" club="C1" country="GER" licencenumber="12346"/>
+        <athlete id="A3" bib="3" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa03" forename="Theo" lastname="Tortenheber" yearofbirth="2002" sex="M" club="C1" country="GER" licencenumber="12347"/>
+        <athlete id="A4" bib="4" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa04" forename="Gertrud" lastname="Gabel" yearofbirth="2002" sex="W" club="C1" country="GER" licencenumber="12348"/>
+    </athletes>
+    <eventdefinitions/>
+    <events>
+        <event id="E1" agecode="M">
+            <standardevent disciplinecode="L100"/>
+        </event>
+        <event id="E2" agecode="M">
+            <standardevent disciplinecode="TWEI"/>
+        </event>
+        <event id="E3" agecode="M">
+            <standardevent disciplinecode="TKUG_7260"/>
+        </event>
+        <event id="E4" agecode="W">
+            <standardevent disciplinecode="M7K"/>
+        </event>
+        <event id="E5" agecode="M">
+            <standardevent disciplinecode="X3X1"/>
+        </event>
+    </events>
+    <individuals>
+        <individual id="I1" event="E1" athlete="A1">
+            <performance date="2022-04-22" disciplinecode="L100" indoor="false" location="Berlin" value="10,220" wind="1,0"/>
+            <yearbest date="2022-04-22" disciplinecode="L100" indoor="false" location="Berlin" value="10,210" wind="1,0"/>
+            <personalbest date="2022-04-22" disciplinecode="L100" indoor="false" location="Berlin" value="10,200" wind="1,0"/>
+        </individual>
+        <individual id="I2" event="E2" athlete="A1">
+            <performance date="2022-04-22" disciplinecode="TWEI" indoor="false" location="Berlin" value="6,22" wind="1,1"/>
+        </individual>
+        <individual id="I3" event="E3" athlete="A1">
+            <performance date="2022-04-22" disciplinecode="TKUG_7260" indoor="false" location="Berlin" value="17,36"/>
+        </individual>
+        <individual id="I4" event="E4" athlete="A4">
+            <performance date="2022-04-22" disciplinecode="M7K" indoor="false" location="Berlin" value="5678"/>
+        </individual>
+    </individuals>
+    <relays>
+        <relay id="R1" club="C1" event="E5">
+            <participant athlete="A1" id="P1"/>
+            <participant athlete="A2" id="P2"/>
+            <participant athlete="A3" id="P3"/>
+            <performance date="2022-04-22" disciplinecode="X3X1" indoor="false" location="Berlin" value="7:18,120"/>
+            <yearbest date="2022-04-22" disciplinecode="X3X1" indoor="false" location="Berlin" value="7:17,120"/>
+            <personalbest date="2022-04-22" disciplinecode="X3X1" indoor="false" location="Berlin" value="7:16,120"/>
+        </relay>
+    </relays>
+</registration>
+

--- a/samples/registration-1.2/teamagegroups.xml
+++ b/samples/registration-1.2/teamagegroups.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<registration version="1.2" location="Berlin" date="2022-06-17" name="Testveranstaltung" competitionnumber="21L20000000003200">
+    <vendor vendor="LADV" programname="LADV" programversion="&lt;version&gt;" website="https://ladv.de"/>
+    <clubs>
+        <club id="C1" number="1234" guid="12345678-abcd-abcd-abcd-cccccccccc01" type="CLUB" name="TSV Musterverein" shortname="TSV Musterverein" country="GER" region="WÜ"/>
+    </clubs>
+    <athletes>
+        <athlete id="A1" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa01" forename="Martin" lastname="Messer" yearofbirth="2011" sex="M" club="C1" country="GER" licencenumber="12345"/>
+        <athlete id="A2" guid="12345678-abcd-abcd-abcd-aaaaaaaaaa02" forename="Gertrud" lastname="Gabel" yearofbirth="2011" sex="W" club="C1" country="GER" licencenumber="12346"/>
+    </athletes>
+    <eventdefinitions/>
+    <events>
+        <event id="E1" agecode="T11">
+            <standardevent disciplinecode="TWEZ"/>
+        </event>
+        <event id="E2" agecode="TU12">
+            <standardevent disciplinecode="XPEN"/>
+        </event>
+    </events>
+    <individuals>
+        <individual id="I1" event="E1" athlete="A1"/>
+        <individual id="I2" event="E1" athlete="A2"/>
+        <individual id="I3" event="E1" athlete="A1"/>
+        <individual id="I4" event="E1" athlete="A2"/>
+    </individuals>
+    <relays>
+        <relay id="R1" club="C1" event="E2">
+            <participant athlete="A1" id="P1"/>
+            <participant athlete="A2" id="P2"/>
+        </relay>
+    </relays>
+</registration>
+

--- a/xsd/registration-1.2.xsd
+++ b/xsd/registration-1.2.xsd
@@ -1,0 +1,396 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xs:schema version="1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:element name="registration" type="registration"/>
+
+  <xs:complexType name="registration">
+    <xs:sequence>
+      <xs:element name="vendor" type="Vendor"/>
+      <xs:element name="clubs" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="club" type="club" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="athletes" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="athlete" type="athlete" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="eventdefinitions" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="eventdefinition" type="EventDefinition" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="events" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="event" type="event" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="individuals" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="individual" type="individual" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="relays" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="relay" type="relay" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="kilas" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="kila" type="kila" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="runs" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="run" type="run" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="version" type="xs:float" use="required"/>
+    <xs:attribute name="location" type="xs:string" use="required"/>
+    <xs:attribute name="date" type="xs:string" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="competitionnumber" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Vendor">
+    <xs:sequence/>
+    <xs:attribute name="vendor" type="xs:string" use="required"/>
+    <xs:attribute name="programname" type="xs:string" use="required"/>
+    <xs:attribute name="programversion" type="xs:string" use="required"/>
+    <xs:attribute name="website" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="club">
+    <xs:sequence/>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+    <xs:attribute name="number" type="xs:int" use="required"/>
+    <xs:attribute name="guid" type="xs:string"/>
+    <xs:attribute name="type" type="clubType" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="shortname" type="xs:string" use="required"/>
+    <xs:attribute name="country" type="xs:string" use="required"/>
+    <xs:attribute name="region" type="xs:string"/>
+    <xs:attribute name="property" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="athlete">
+    <xs:sequence/>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+    <xs:attribute name="bib" type="xs:int"/>
+    <xs:attribute name="guid" type="xs:string"/>
+    <xs:attribute name="forename" type="xs:string" use="required"/>
+    <xs:attribute name="lastname" type="xs:string" use="required"/>
+    <xs:attribute name="yearofbirth" type="xs:int" use="required"/>
+    <xs:attribute name="sex" type="sex" use="required"/>
+    <xs:attribute name="club" type="xs:IDREF" use="required"/>
+    <xs:attribute name="country" type="xs:string"/>
+    <xs:attribute name="property" type="xs:string"/>
+    <xs:attribute name="licencenumber" type="xs:int"/>
+  </xs:complexType>
+
+  <xs:complexType name="EventDefinition">
+    <xs:sequence/>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="shortname" type="xs:string" use="required"/>
+    <xs:attribute name="eventtype" type="EventType" use="required"/>
+    <xs:attribute name="formattype" type="FormatType" use="required"/>
+    <xs:attribute name="precision" type="Precision" use="required"/>
+    <xs:attribute name="vendorcode" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="event">
+    <xs:sequence>
+      <xs:choice minOccurs="0">
+        <xs:element name="standardevent" type="StandardEvent"/>
+        <xs:element name="customevent" type="CustomEvent"/>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+    <xs:attribute name="agecode" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="StandardEvent">
+    <xs:sequence/>
+    <xs:attribute name="disciplinecode" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="CustomEvent">
+    <xs:sequence/>
+    <xs:attribute name="eventdefinition" type="xs:IDREF" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="individual">
+    <xs:sequence>
+      <xs:element name="performance" type="performance" minOccurs="0"/>
+      <xs:element name="yearbest" type="performance" minOccurs="0"/>
+      <xs:element name="personalbest" type="performance" minOccurs="0"/>
+      <xs:element name="comment" type="comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+    <xs:attribute name="event" type="xs:IDREF" use="required"/>
+    <xs:attribute name="athlete" type="xs:IDREF" use="required"/>
+    <xs:attribute name="alliance" type="xs:IDREF"/>
+    <xs:attribute name="lateregistration" type="xs:boolean"/>
+    <xs:attribute name="notranked" type="xs:boolean"/>
+    <xs:attribute name="property" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="performance">
+    <xs:sequence/>
+    <xs:attribute name="date" type="xs:string"/>
+    <xs:attribute name="disciplinecode" type="xs:string"/>
+    <xs:attribute name="handTime" type="xs:boolean"/>
+    <xs:attribute name="indoor" type="xs:boolean" use="required"/>
+    <xs:attribute name="location" type="xs:string"/>
+    <xs:attribute name="notdocumented" type="xs:boolean"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
+    <xs:attribute name="wind" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="comment">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="authorname" type="xs:string" use="required"/>
+        <xs:attribute name="order" type="xs:int" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="relay">
+    <xs:sequence>
+      <xs:element name="participant" type="participant" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="performance" type="performance" minOccurs="0"/>
+      <xs:element name="yearbest" type="performance" minOccurs="0"/>
+      <xs:element name="personalbest" type="performance" minOccurs="0"/>
+      <xs:element name="comment" type="comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+    <xs:attribute name="club" type="xs:IDREF" use="required"/>
+    <xs:attribute name="event" type="xs:IDREF" use="required"/>
+    <xs:attribute name="lateregistration" type="xs:boolean"/>
+    <xs:attribute name="notranked" type="xs:boolean"/>
+    <xs:attribute name="property" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="participant">
+    <xs:sequence/>
+    <xs:attribute name="athlete" type="xs:IDREF" use="required"/>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+    <xs:attribute name="property" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="kila">
+    <xs:sequence>
+      <xs:element name="participant" type="participant" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="comment" type="comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="club" type="xs:IDREF"/>
+    <xs:attribute name="event" type="xs:IDREF" use="required"/>
+    <xs:attribute name="lateregistration" type="xs:boolean"/>
+    <xs:attribute name="notranked" type="xs:boolean"/>
+    <xs:attribute name="property" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="run">
+    <xs:sequence>
+      <xs:element name="participant" type="participant" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required"/>
+    <xs:attribute name="disciplinecode" type="xs:string" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="agecodes">
+      <xs:simpleType>
+        <xs:list itemType="AgeCode"/>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="distance" type="xs:int"/>
+    <xs:attribute name="property" type="xs:string"/>
+    <xs:attribute name="trackid" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:simpleType name="clubType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="CLUB"/>
+      <xs:enumeration value="STG"/>
+      <xs:enumeration value="LG"/>
+      <xs:enumeration value="OTHER"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="sex">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="M"/>
+      <xs:enumeration value="W"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="EventType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="INDIVIDUAL"/>
+      <xs:enumeration value="COMBINEDEVENT"/>
+      <xs:enumeration value="INDIVIDUALTEAM"/>
+      <xs:enumeration value="RELAY"/>
+      <xs:enumeration value="COMBINEDEVENTTEAM"/>
+      <xs:enumeration value="TEAMCHAMPIONCHIP"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="FormatType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="POINTS"/>
+      <xs:enumeration value="METRIC"/>
+      <xs:enumeration value="TIME"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Precision">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="METER"/>
+      <xs:enumeration value="CENTIMETER"/>
+      <xs:enumeration value="SECOND_FULL"/>
+      <xs:enumeration value="SECOND_10TH"/>
+      <xs:enumeration value="SECOND_100TH"/>
+      <xs:enumeration value="SECOND_1000TH"/>
+      <xs:enumeration value="POINTS_FULL"/>
+      <xs:enumeration value="POINTS_10TH"/>
+      <xs:enumeration value="POINTS_100TH"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="AgeCode">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="M3"/>
+      <xs:enumeration value="M4"/>
+      <xs:enumeration value="M5"/>
+      <xs:enumeration value="M6"/>
+      <xs:enumeration value="M7"/>
+      <xs:enumeration value="M8"/>
+      <xs:enumeration value="M9"/>
+      <xs:enumeration value="M10"/>
+      <xs:enumeration value="M11"/>
+      <xs:enumeration value="M12"/>
+      <xs:enumeration value="M13"/>
+      <xs:enumeration value="M14"/>
+      <xs:enumeration value="M15"/>
+      <xs:enumeration value="MKU6"/>
+      <xs:enumeration value="MKU8"/>
+      <xs:enumeration value="MKU10"/>
+      <xs:enumeration value="MKU12"/>
+      <xs:enumeration value="MJU14"/>
+      <xs:enumeration value="MJU16"/>
+      <xs:enumeration value="MJU18"/>
+      <xs:enumeration value="MJU20"/>
+      <xs:enumeration value="MU23"/>
+      <xs:enumeration value="M"/>
+      <xs:enumeration value="MJEDER"/>
+      <xs:enumeration value="M30"/>
+      <xs:enumeration value="M35"/>
+      <xs:enumeration value="M40"/>
+      <xs:enumeration value="M45"/>
+      <xs:enumeration value="M50"/>
+      <xs:enumeration value="M55"/>
+      <xs:enumeration value="M60"/>
+      <xs:enumeration value="M65"/>
+      <xs:enumeration value="M70"/>
+      <xs:enumeration value="M75"/>
+      <xs:enumeration value="M80"/>
+      <xs:enumeration value="M85"/>
+      <xs:enumeration value="M90"/>
+      <xs:enumeration value="M95"/>
+      <xs:enumeration value="W3"/>
+      <xs:enumeration value="W4"/>
+      <xs:enumeration value="W5"/>
+      <xs:enumeration value="W6"/>
+      <xs:enumeration value="W7"/>
+      <xs:enumeration value="W8"/>
+      <xs:enumeration value="W9"/>
+      <xs:enumeration value="W10"/>
+      <xs:enumeration value="W11"/>
+      <xs:enumeration value="W12"/>
+      <xs:enumeration value="W13"/>
+      <xs:enumeration value="W14"/>
+      <xs:enumeration value="W15"/>
+      <xs:enumeration value="WKU6"/>
+      <xs:enumeration value="WKU8"/>
+      <xs:enumeration value="WKU10"/>
+      <xs:enumeration value="WKU12"/>
+      <xs:enumeration value="WJU14"/>
+      <xs:enumeration value="WJU16"/>
+      <xs:enumeration value="WJU18"/>
+      <xs:enumeration value="WJU20"/>
+      <xs:enumeration value="WU23"/>
+      <xs:enumeration value="W"/>
+      <xs:enumeration value="WJEDER"/>
+      <xs:enumeration value="W30"/>
+      <xs:enumeration value="W35"/>
+      <xs:enumeration value="W40"/>
+      <xs:enumeration value="W45"/>
+      <xs:enumeration value="W50"/>
+      <xs:enumeration value="W55"/>
+      <xs:enumeration value="W60"/>
+      <xs:enumeration value="W65"/>
+      <xs:enumeration value="W70"/>
+      <xs:enumeration value="W75"/>
+      <xs:enumeration value="W80"/>
+      <xs:enumeration value="W85"/>
+      <xs:enumeration value="W90"/>
+      <xs:enumeration value="W95"/>
+      <xs:enumeration value="T6"/>
+      <xs:enumeration value="T7"/>
+      <xs:enumeration value="T8"/>
+      <xs:enumeration value="T9"/>
+      <xs:enumeration value="T10"/>
+      <xs:enumeration value="T11"/>
+      <xs:enumeration value="TU6"/>
+      <xs:enumeration value="TU8"/>
+      <xs:enumeration value="TU10"/>
+      <xs:enumeration value="TU12"/>
+      <xs:enumeration value="X12"/>
+      <xs:enumeration value="X13"/>
+      <xs:enumeration value="X14"/>
+      <xs:enumeration value="X15"/>
+      <xs:enumeration value="XJU14"/>
+      <xs:enumeration value="XJU16"/>
+      <xs:enumeration value="XJU18"/>
+      <xs:enumeration value="XJU20"/>
+      <xs:enumeration value="XU23"/>
+      <xs:enumeration value="X"/>
+      <xs:enumeration value="X30"/>
+      <xs:enumeration value="X35"/>
+      <xs:enumeration value="X40"/>
+      <xs:enumeration value="X45"/>
+      <xs:enumeration value="X50"/>
+      <xs:enumeration value="X55"/>
+      <xs:enumeration value="X60"/>
+      <xs:enumeration value="X65"/>
+      <xs:enumeration value="X70"/>
+      <xs:enumeration value="X75"/>
+      <xs:enumeration value="X80"/>
+      <xs:enumeration value="X85"/>
+      <xs:enumeration value="X90"/>
+      <xs:enumeration value="X95"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>
+


### PR DESCRIPTION
- rename athlete.number to athlete.licencenumber (consistency)
- add athlete.bib (Startnummer)
- add yearbest and personalbest to individual and relay
- add element run for nonstadia registration
- add generic property
- add samples for registration 1.2
- add xsd for registration 1.2

Signed-off-by: Marc Schunk <Marc.Schunk@ladv.de>
Co-authored-by: Marc Schunk <Marc.Schunk@ladv.de>